### PR TITLE
Fix heating state

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homebridge-rinnai-controlr",
-  "version": "1.0.24",
+  "version": "1.0.27",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "homebridge-rinnai-controlr",
-      "version": "1.0.24",
+      "version": "1.0.27",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/api-graphql": "^3.0.11",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Homebridge Rinnai Control-R",
   "name": "homebridge-rinnai-controlr",
-  "version": "1.0.24",
+  "version": "1.0.27",
   "description": "Integrates with Rinnai Control-R for HomeKit control of water heaters",
   "license": "Apache-2.0",
   "repository": {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -259,11 +259,14 @@ export const API_KEY_SET_PRIORITY_STATUS = 'set_priority_status';
 export const API_KEY_RECIRCULATION_DURATION = 'recirculation_duration';
 export const API_KEY_SET_RECIRCULATION_ENABLED = 'set_recirculation_enabled';
 export const API_KEY_SET_TEMPERATURE = 'set_domestic_temperature';
+export const API_KEY_DO_MAINTENANCE_RETRIEVAL = 'do_maintenance_retrieval';
 export const API_VALUE_TRUE = 'true';
 export const API_VALUE_FALSE = 'false';
 
 export const API_POLL_THROTTLE_MILLIS = 1000;
 export const SET_STATE_WAIT_TIME_MILLIS = 5000;
+
+export const ACCESSARY_INFO_UPDATE_THROTTLE_MILLIS = 30000;
 
 export const MANUFACTURER = 'Rinnai';
 export const UNKNOWN = 'Unknown';
@@ -273,8 +276,20 @@ export enum TemperatureUnits {
     F = 'F',
 }
 
-export const THERMOSTAT_STEP_VALUE = 0.5; // in C, as HomeKit uses this unit for accessories
-export const WATER_HEATER_STEP_VALUE_IN_F = 2; // Controllers with the imperial unit, use 98/100/102/etc
+// All numbers below use metric units (C), as required by HomeKit APIs
+export const THERMOSTAT_TARGET_TEMP_STEP_VALUE = 1;
+
+export const THERMOSTAT_CURRENT_TEMP_STEP_VALUE = 0.5;
+export const THERMOSTAT_CURRENT_TEMP_MAX_VALUE = 65; // 60C for residential water heater based on the manual, adding 5 as buffer
+export const THERMOSTAT_CURRENT_TEMP_MIN_VALUE = 0; // 0C, frozen pipe...
+
+/**
+ * For water heater controllers with the imperial unit,
+ * the steps are 98/100/102/.../108/110/105/110/115/120/...
+ */
+export const WATER_HEATER_SMALL_STEP_VALUE_IN_F = 2;
+export const WATER_HEATER_BIG_STEP_START_IN_F = 110;
+export const WATER_HEATER_BIG_STEP_VALUE_IN_F = 5;
 
 // Increment only for breaking service changes to remove and re-add devices
 export const PREVIOUS_UUID_SUFFICES = ['-1'];

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -263,11 +263,11 @@ export const API_KEY_DO_MAINTENANCE_RETRIEVAL = 'do_maintenance_retrieval';
 export const API_VALUE_TRUE = 'true';
 export const API_VALUE_FALSE = 'false';
 
-export const API_POLL_THROTTLE_MILLIS = 1000;
+export const API_POLL_THROTTLE_MILLIS = 30000;
 export const SET_STATE_WAIT_TIME_MILLIS = 5000;
 
 export const MAINTENANCE_RETRIEVAL_RUNNING_THROTTLE_MILLIS = 30000; // 30 secs when heater is running
-export const MAINTENANCE_RETRIEVAL_IDLE_THROTTLE_MILLIS = 300000; // 5 mins when heater is idling
+export const MAINTENANCE_RETRIEVAL_IDLING_THROTTLE_MILLIS = 600000; // 10 mins when heater is idling
 
 export const MANUFACTURER = 'Rinnai';
 export const UNKNOWN = 'Unknown';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -266,7 +266,8 @@ export const API_VALUE_FALSE = 'false';
 export const API_POLL_THROTTLE_MILLIS = 1000;
 export const SET_STATE_WAIT_TIME_MILLIS = 5000;
 
-export const MAINTENANCE_RETRIEVAL_THROTTLE_MILLIS = 30000;
+export const MAINTENANCE_RETRIEVAL_RUNNING_THROTTLE_MILLIS = 30000; // 30 secs when heater is running
+export const MAINTENANCE_RETRIEVAL_IDLE_THROTTLE_MILLIS = 300000; // 5 mins when heater is idling
 
 export const MANUFACTURER = 'Rinnai';
 export const UNKNOWN = 'Unknown';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -266,7 +266,7 @@ export const API_VALUE_FALSE = 'false';
 export const API_POLL_THROTTLE_MILLIS = 1000;
 export const SET_STATE_WAIT_TIME_MILLIS = 5000;
 
-export const ACCESSARY_INFO_UPDATE_THROTTLE_MILLIS = 30000;
+export const MAINTENANCE_RETRIEVAL_THROTTLE_MILLIS = 30000;
 
 export const MANUFACTURER = 'Rinnai';
 export const UNKNOWN = 'Unknown';

--- a/src/platformAccessory.ts
+++ b/src/platformAccessory.ts
@@ -186,10 +186,10 @@ export class RinnaiControlrPlatformAccessory {
     accessoryToControllerTemperature(value: number): number {
         let convertedValue: number = this.isFahrenheit ? celsiusToFahrenheit(value) : value;
         if (this.isFahrenheit) {
-            if (convertedValue >=  WATER_HEATER_BIG_STEP_START_IN_F) {
-                convertedValue = Math.round(celsiusToFahrenheit(convertedValue) / WATER_HEATER_SMALL_STEP_VALUE_IN_F) * WATER_HEATER_SMALL_STEP_VALUE_IN_F
+            if (convertedValue <  WATER_HEATER_BIG_STEP_START_IN_F) {
+                convertedValue = Math.round(convertedValue / WATER_HEATER_SMALL_STEP_VALUE_IN_F) * WATER_HEATER_SMALL_STEP_VALUE_IN_F
             } else {
-                convertedValue = Math.round(celsiusToFahrenheit(convertedValue) / WATER_HEATER_BIG_STEP_VALUE_IN_F) * WATER_HEATER_BIG_STEP_VALUE_IN_F
+                convertedValue = Math.round(convertedValue / WATER_HEATER_BIG_STEP_VALUE_IN_F) * WATER_HEATER_BIG_STEP_VALUE_IN_F
             }
         } else {
             convertedValue = Math.round(convertedValue);

--- a/src/platformAccessory.ts
+++ b/src/platformAccessory.ts
@@ -14,7 +14,7 @@ import {
     THERMOSTAT_CURRENT_TEMP_MAX_VALUE,
     THERMOSTAT_CURRENT_TEMP_MIN_VALUE,
     UNKNOWN,
-    MAINTENANCE_RETRIEVAL_IDLE_THROTTLE_MILLIS,
+    MAINTENANCE_RETRIEVAL_IDLING_THROTTLE_MILLIS,
     MAINTENANCE_RETRIEVAL_RUNNING_THROTTLE_MILLIS,
     API_VALUE_FALSE,
     THERMOSTAT_CURRENT_TEMP_STEP_VALUE,
@@ -93,7 +93,7 @@ export class RinnaiControlrPlatformAccessory {
             this.platform.log.error(`Cannot extract details from ${JSON.stringify(this.accessory.context, null, 2)}`);
         }
 
-        this.platform.log.info(`Water Heater ${this.accessory.context.id}: ` +
+        this.platform.log.debug(`Water Heater ${this.accessory.context.id}: ` +
             `targetTemperature = ${this.targetTemperature}, ` +
             `outletTemperature = ${this.outletTemperature}, ` +
             `isRunning = ${this.isRunning}`);
@@ -229,7 +229,7 @@ export class RinnaiControlrPlatformAccessory {
         this.extractDeviceInfo();
     }
 
-    public pollMaintenanceInfoWhenIdling = _.throttle(this.pollMaintenanceInfo, MAINTENANCE_RETRIEVAL_IDLE_THROTTLE_MILLIS);
+    public pollMaintenanceInfoWhenIdling = _.throttle(this.pollMaintenanceInfo, MAINTENANCE_RETRIEVAL_IDLING_THROTTLE_MILLIS);
     public pollMaintenanceInfoWhenRunning = _.throttle(this.pollMaintenanceInfo, MAINTENANCE_RETRIEVAL_RUNNING_THROTTLE_MILLIS);
 
     async getTargetTemperature(): Promise<Nullable<CharacteristicValue>> {

--- a/src/platformAccessory.ts
+++ b/src/platformAccessory.ts
@@ -56,7 +56,7 @@ export class RinnaiControlrPlatformAccessory {
 
         this.minValue = Math.floor(this.minValue / THERMOSTAT_TARGET_TEMP_STEP_VALUE) * THERMOSTAT_TARGET_TEMP_STEP_VALUE;
         this.maxValue = Math.ceil(this.maxValue / THERMOSTAT_TARGET_TEMP_STEP_VALUE) * THERMOSTAT_TARGET_TEMP_STEP_VALUE;
-        this.platform.log.debug(`Target Temperature Slider Min: ${this.minValue}, Max: ${this.maxValue}`);
+        this.platform.log.info(`Water Heater ${this.accessory.context.id}: Target Temperature Slider Min: ${this.minValue}, Max: ${this.maxValue}`);
 
         this.extractDeviceInfo();
 
@@ -92,10 +92,10 @@ export class RinnaiControlrPlatformAccessory {
             this.platform.log.error(`Cannot extract details from ${JSON.stringify(this.accessory.context, null, 2)}`);
         }
 
-        this.platform.log.debug(`Extracted device info: ` +
-            `target temperature = ${this.targetTemperature}, ` +
-            `outlet temperature = ${this.outletTemperature}, ` +
-            `is running = ${this.isRunning}`);
+        this.platform.log.info(`Water Heater ${this.accessory.context.id}: ` +
+            `targetTemperature = ${this.targetTemperature}, ` +
+            `outletTemperature = ${this.outletTemperature}, ` +
+            `isRunning = ${this.isRunning}`);
     }
 
     bindTemperature() {
@@ -202,10 +202,10 @@ export class RinnaiControlrPlatformAccessory {
     }
 
     async setTargetTemperature(value: CharacteristicValue) {
-        this.platform.log.info(`setTemperature to ${value} C for device ${this.accessory.context.id}`);
+        this.platform.log.info(`Water Heater ${this.accessory.context.id}: HomeKit sets target temperature to ${value}C`);
 
         const convertedValue = this.accessoryToControllerTemperature(value as number);
-        this.platform.log.info(`Sending converted/rounded temperature: ${convertedValue} ${this.platform.getConfig().temperatureUnits}`);
+        this.platform.log.info(`Water Heater ${this.accessory.context.id}: Sending converted/rounded temperature: ${convertedValue}${this.platform.getConfig().temperatureUnits}`);
 
         const state: Record<string, string | number | boolean> = {
             [API_KEY_SET_PRIORITY_STATUS]: true,

--- a/src/platformAccessory.ts
+++ b/src/platformAccessory.ts
@@ -179,10 +179,6 @@ export class RinnaiControlrPlatformAccessory {
         await this.platform.setState(this.accessory, state);
     }
 
-    public throttledRetrieveMaintenanceInfo = _.throttle(async () => {
-        await this.retrieveMaintenanceInfo();
-    }, MAINTENANCE_RETRIEVAL_THROTTLE_MILLIS);
-
     accessoryToControllerTemperature(value: number): number {
         let convertedValue: number = this.isFahrenheit ? celsiusToFahrenheit(value) : value;
         if (this.isFahrenheit) {
@@ -222,12 +218,12 @@ export class RinnaiControlrPlatformAccessory {
     }
 
     public throttledPollDeviceInfo = _.throttle(async () => {
-        await this.throttledRetrieveMaintenanceInfo()
+        await this.retrieveMaintenanceInfo();
 
         await this.platform.throttledPoll();
 
         this.extractDeviceInfo();
-    }, SET_STATE_WAIT_TIME_MILLIS);
+    }, MAINTENANCE_RETRIEVAL_THROTTLE_MILLIS);
 
     async getTargetTemperature(): Promise<Nullable<CharacteristicValue>> {
         await this.throttledPollDeviceInfo();


### PR DESCRIPTION
This is to address the issue reported in https://github.com/dustindclark/homebridge-rinnai-controlr/issues/2

* Always set Heat as target state (will show "Heat to" in Home.app)
* Set Heat as current state when combustion is on (will show "Heating to" in Home.app and the number will turn Orange); otherwise, set Off as current state (the number will stay White)
* Display the outlet temperature as the current temperature, so that it better match the UX of ("Heat to" / "Heating to")

Example when the combustion is on
![image](https://github.com/zimuliu/homebridge-rinnai-controlr/assets/1153378/9e54dffa-847c-423c-91d6-1f550b94960a)

Example when the combustion is off
![image](https://github.com/zimuliu/homebridge-rinnai-controlr/assets/1153378/4975f69a-f318-4a57-afa3-0e0edcdf3025)