### PR TITLE
Use proper rounding for controllers with imperial units

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -40,14 +40,14 @@
         "description": "Minimum temperature to be used by HomeKit slider. Use same units as configured above.",
         "type": "number",
         "required": true,
-        "default": "120"
+        "default": "98"
       },
       "maximumTemperature": {
         "title": "Maximum Temperature",
         "description": "Maximum temperature to be used by HomeKit slider. Use same units as configured above.",
         "type": "number",
         "required": true,
-        "default": "140"
+        "default": "120"
       }
     }
   }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -273,7 +273,8 @@ export enum TemperatureUnits {
     F = 'F',
 }
 
-export const THERMOSTAT_STEP_VALUE = 0.5;
+export const THERMOSTAT_STEP_VALUE = 0.5; // in C, as HomeKit uses this unit for accessories
+export const WATER_HEATER_STEP_VALUE_IN_F = 2; // Controllers with the imperial unit, use 98/100/102/etc
 
 // Increment only for breaking service changes to remove and re-add devices
 export const PREVIOUS_UUID_SUFFICES = [''];


### PR DESCRIPTION
The controllers in US/Canada use steps like 98F/100F/102F/etc with 2F step size. This PR ensures that we properly set the temperature, based on the target temp picked by customers in the Home.app.

This PR also fixed
*  the wrong defaults
* a wrong log output
* the rounding error on the temperature range


